### PR TITLE
feat: alpha blending, device-pixel clipping, and external-source mode (v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,38 @@ A custom Mapbox GL JS layer for comparing raster tile sources.
 
 ```typescript
 new ComparisonLayer(
-  id: string,              // Unique layer identifier
-  sourceId: string,        // Source ID for overlay tiles
-  tileJson: RasterSource,  // Mapbox raster source specification
-  data: {                  // Initial offset configuration
-    offsetX: number;       // Horizontal offset (0-1)
-    offsetY: number;       // Vertical offset (0-1)
+  id: string,                     // Unique layer identifier
+  sourceId: string,               // Source ID for overlay tiles
+  tileJson: RasterSource | null,  // Raster source spec, or null to render an existing source
+  data: {                         // Initial offset configuration
+    offsetX: number;              // Horizontal offset (0-1)
+    offsetY: number;              // Vertical offset (0-1)
+    opacity?: number;             // Overlay opacity (0-1, default 1)
   }
 )
 ```
+
+#### External-source mode
+
+Pass `null` as `tileJson` to render a raster source your app already owns. The
+layer then never calls `addSource`/`removeSource` — it only draws from the
+existing source's tile cache. Keep the source "used" (so mapbox loads and
+updates its tiles) by also adding a regular raster layer with
+`'raster-opacity': 0`:
+
+```typescript
+map.addSource("overlay-source", { type: "raster", tiles: [url] });
+map.addLayer({
+  id: "overlay-loader",
+  type: "raster",
+  source: "overlay-source",
+  paint: { "raster-opacity": 0 },
+});
+map.addLayer(new ComparisonLayer("comparison-layer", "overlay-source", null, { offsetX: 0.5, offsetY: 0 }));
+```
+
+This is the recommended mode for apps whose framework (e.g. react-map-gl)
+owns source lifecycles and restores them across style swaps.
 
 #### Methods
 
@@ -93,6 +116,18 @@ new ComparisonLayer(
 | `id` | `string` | Layer identifier |
 | `sourceId` | `string` | Overlay source identifier |
 | `type` | `"custom"` | Mapbox layer type |
+
+## Rendering notes
+
+- **Alpha blending**: tiles are composited with premultiplied-alpha blending
+  (matching how mapbox uploads raster textures), and fully transparent texels
+  are discarded — bounded tile sources with transparent padding render
+  correctly over the basemap.
+- **Device-pixel clipping**: the comparison edge is computed in device pixels,
+  so it is exact on any `devicePixelRatio` (retina, browser zoom).
+- **Globe projection**: rendering is skipped while the map is in true globe
+  projection (low zoom); above the globe-to-mercator transition zoom the
+  overlay renders normally.
 
 ## How It Works
 

--- a/lib/CustomLayer.ts
+++ b/lib/CustomLayer.ts
@@ -33,20 +33,22 @@ interface ComparisonLayerProgram extends WebGLProgram {
   aPos: number;
   uMatrix: WebGLUniformLocation | null;
   uTexture: WebGLUniformLocation | null;
-  uOffsetX: WebGLUniformLocation | null;
-  uOffsetY: WebGLUniformLocation | null;
-  uDevicePixelRatio: WebGLUniformLocation | null;
+  uClipX: WebGLUniformLocation | null;
+  uClipY: WebGLUniformLocation | null;
+  uOpacity: WebGLUniformLocation | null;
   vertexBuffer: WebGLBuffer | null;
 }
 
 /**
  * Data object controlling the comparison layer visibility.
- * @property offsetX - Horizontal offset (0-1), where the overlay becomes visible
- * @property offsetY - Vertical offset (0-1), where the overlay becomes visible
+ * @property offsetX - Horizontal offset (0-1); the overlay is visible left of it
+ * @property offsetY - Vertical offset (0-1); the overlay is visible above it
+ * @property opacity - Overlay opacity (0-1, default 1)
  */
 export type ComparisonLayerData = {
   offsetX: number;
   offsetY: number;
+  opacity?: number;
 };
 
 /**
@@ -56,12 +58,32 @@ export type ComparisonLayerData = {
  * using WebGL shaders for efficient rendering. The visible area can be
  * controlled via offsetX and offsetY properties.
  *
+ * Two source modes:
+ * - **Owned source** (pass `tileJson`): the layer adds the raster source
+ *   itself and keeps its tile cache updated on map movement.
+ * - **External source** (pass `null` for `tileJson`): the layer only renders
+ *   an existing raster source. The host app owns the source lifecycle — add
+ *   the source plus a regular raster layer with `'raster-opacity': 0` so
+ *   mapbox marks the source as used and loads/updates tiles through its
+ *   normal pipeline. This mode survives style swaps as long as the host
+ *   re-adds the source and this layer.
+ *
  * @example
  * ```typescript
+ * // Owned source
  * const layer = new ComparisonLayer(
  *   "comparison-layer",
  *   "overlay-source",
  *   { type: "raster", tiles: ["https://example.com/{z}/{x}/{y}.png"] },
+ *   { offsetX: 0.5, offsetY: 0 }
+ * );
+ * map.addLayer(layer);
+ *
+ * // External source (host owns "overlay-source")
+ * const layer = new ComparisonLayer(
+ *   "comparison-layer",
+ *   "overlay-source",
+ *   null,
  *   { offsetX: 0.5, offsetY: 0 }
  * );
  * map.addLayer(layer);
@@ -76,7 +98,7 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
   private tileSource: mapboxgl.AnySourceImpl | null;
   public readonly sourceId: string;
   type: "custom";
-  private tileJson: mapboxgl.RasterSource;
+  private tileJson: mapboxgl.RasterSource | null;
   // Custom data
   private program: ComparisonLayerProgram | null;
   private sourceCache: any;
@@ -84,6 +106,9 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
   private mapWidth = 0;
   private mapHeight = 0;
   private observer: ResizeObserver | null = null;
+  // Bound handlers kept so onRemove detaches the same references.
+  private boundMove: (() => void) | null = null;
+  private boundOnData: ((e: any) => void) | null = null;
   // Callbacks
   private onAddCallback: onAddCallback;
   private renderCallback: onRenderCallback;
@@ -94,7 +119,8 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
    *
    * @param id - Unique identifier for this layer
    * @param sourceId - Identifier for the raster source to overlay
-   * @param tileJson - Mapbox RasterSource specification for the overlay tiles
+   * @param tileJson - Mapbox RasterSource specification for the overlay
+   *   tiles, or `null` to render an existing source owned by the host app
    * @param data - Initial offset configuration (offsetX and offsetY, 0-1 range)
    * @param onAddCallback - Custom initialization callback (defaults to setupLayer)
    * @param renderCallback - Custom render callback (defaults to render)
@@ -103,7 +129,7 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
   constructor(
     id: string,
     sourceId: string,
-    tileJson: mapboxgl.RasterSource,
+    tileJson: mapboxgl.RasterSource | null,
     data: ComparisonLayerData,
     onAddCallback: onAddCallback = setupLayer,
     renderCallback: onRenderCallback = render,
@@ -126,39 +152,47 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
   onAdd(map: mapboxgl.Map, gl: WebGLRenderingContext) {
     this.map = map;
     this.gl = gl;
-    map.on("move", this.move.bind(this));
-    map.on("zoom", this.zoom.bind(this));
 
-    map.addSource(this.sourceId, this.tileJson);
-    this.tileSource = this.map.getSource(this.sourceId);
-    //@ts-ignore
-    this.tileSource.on("data", this.onData.bind(this));
-    //@ts-ignore
-    this.sourceCache = this.map.style._sourceCaches[`other:${this.sourceId}`];
+    if (this.tileJson) {
+      // Owned-source mode: create the source and keep its cache updated.
+      this.boundMove = this.move.bind(this);
+      map.on("move", this.boundMove);
 
-    // !IMPORTANT! hack to make mapbox mark the sourceCache as 'used' so it will initialise tiles.
-    //@ts-ignore
-    this.map.style._layers[this.id].source = this.sourceId;
-    //@ts-ignore
+      map.addSource(this.sourceId, this.tileJson);
+      this.tileSource = this.map.getSource(this.sourceId);
+      this.boundOnData = this.onData.bind(this);
+      //@ts-ignore
+      this.tileSource.on("data", this.boundOnData);
+      this.sourceCache = this.resolveSourceCache();
+
+      // !IMPORTANT! hack to make mapbox mark the sourceCache as 'used' so it will initialise tiles.
+      //@ts-ignore
+      this.map.style._layers[this.id].source = this.sourceId;
+    } else {
+      // External-source mode: the host app owns the source (and keeps it
+      // used via a regular raster layer), we only render from its cache.
+      // The source may not exist yet — render() re-resolves lazily.
+      this.sourceCache = this.resolveSourceCache();
+    }
+
     if (this.onAddCallback) {
       this.program = this.onAddCallback(map, gl, this.data);
     }
 
-    // Update initial data
+    // Track container size for custom render callbacks.
     const rect = map.getContainer().getBoundingClientRect();
     this.mapWidth = rect.width;
     this.mapHeight = rect.height;
 
-    // Observe
-    this.observer = new ResizeObserver(() => this.onResize(map));
-    this.observer.observe(map.getContainer());
+    if (typeof ResizeObserver !== "undefined") {
+      this.observer = new ResizeObserver(() => this.onResize(map));
+      this.observer.observe(map.getContainer());
+    }
   }
 
   move() {
     this.updateTiles();
   }
-
-  zoom() {}
 
   private onResize(map: mapboxgl.Map) {
     const rect = map.getContainer().getBoundingClientRect();
@@ -175,7 +209,7 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
 
   updateTiles() {
     //@ts-ignore
-    this.sourceCache.update(this.map.painter.transform);
+    this.sourceCache?.update(this.map?.painter?.transform);
   }
 
   /**
@@ -188,50 +222,47 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
   }
 
   prerender(gl: WebGLRenderingContext, matrix: number[]) {
-    if (this.preRenderCallback)
-      this.preRenderCallback(
-        //@ts-ignore
-        gl,
-        matrix,
-        this.sourceCache
-          .getVisibleCoordinates()
-          //@ts-ignore
-          .map((tileid) => this.sourceCache.getTile(tileid))
-      );
+    if (!this.preRenderCallback) return;
+    const tiles = this.visibleTiles();
+    if (!tiles) return;
+    //@ts-ignore
+    this.preRenderCallback(gl, matrix, tiles);
   }
 
   render(gl: WebGLRenderingContext, matrix: number[]) {
-    if (this.renderCallback && this.program)
-      this.renderCallback(
-        //@ts-ignore
-        gl,
-        matrix,
-        this.sourceCache
-          .getVisibleCoordinates()
-          //@ts-ignore
-          .map((tileid) => this.sourceCache.getTile(tileid)),
-        this.program,
-        this.data,
-        this.mapWidth,
-        this.mapHeight
-      );
+    if (!this.renderCallback || !this.program) return;
+    const tiles = this.visibleTiles();
+    if (!tiles) return;
+    this.renderCallback(
+      gl,
+      matrix,
+      tiles,
+      this.program,
+      this.data,
+      this.mapWidth,
+      this.mapHeight
+    );
   }
 
   /**
    * Cleans up resources when the layer is removed from the map.
    * Removes event listeners, disconnects the ResizeObserver, and cleans up WebGL resources.
+   * In external-source mode the source is left untouched — the host app owns it.
    */
   onRemove() {
     if (this.map) {
-      this.map.off("move", this.move.bind(this));
-      this.map.off("zoom", this.zoom.bind(this));
-
-      if (this.tileSource) {
-        //@ts-ignore
-        this.tileSource.off("data", this.onData.bind(this));
+      if (this.boundMove) {
+        this.map.off("move", this.boundMove);
+        this.boundMove = null;
       }
 
-      if (this.map.getSource(this.sourceId)) {
+      if (this.tileSource && this.boundOnData) {
+        //@ts-ignore
+        this.tileSource.off("data", this.boundOnData);
+        this.boundOnData = null;
+      }
+
+      if (this.tileJson && this.map.getSource(this.sourceId)) {
         this.map.removeSource(this.sourceId);
       }
     }
@@ -253,6 +284,45 @@ export class ComparisonLayer implements mapboxgl.CustomLayerInterface {
     this.gl = null;
     this.tileSource = null;
     this.sourceCache = null;
+  }
+
+  /**
+   * Resolves the mapbox source cache for `sourceId`.
+   * Uses `getOwnSourceCache` where available, with a fallback to the private
+   * `_sourceCaches` map. Both are mapbox internals — re-verify on upgrades.
+   */
+  private resolveSourceCache(): any {
+    //@ts-ignore
+    const style: any = this.map?.style;
+    if (!style) return null;
+    return (
+      style.getOwnSourceCache?.(this.sourceId) ??
+      style._sourceCaches?.[`other:${this.sourceId}`] ??
+      null
+    );
+  }
+
+  /**
+   * Returns the visible tiles to draw, or null when rendering should be
+   * skipped (no cache yet, fully hidden, or true-globe projection where
+   * `tileID.projMatrix` is not a mercator matrix).
+   */
+  private visibleTiles(): any[] | null {
+    if (this.data.offsetX <= 0 || this.data.offsetY >= 1) return null;
+
+    // In globe projection the mercator tile matrices would misproject the
+    // quads. Above the globe-to-mercator transition zoom, mapbox reports the
+    // transform's projection as mercator again, so this only skips true globe.
+    //@ts-ignore
+    const projectionName = this.map?.transform?.projection?.name;
+    if (projectionName === "globe") return null;
+
+    if (!this.sourceCache) this.sourceCache = this.resolveSourceCache();
+    if (!this.sourceCache) return null;
+
+    return this.sourceCache
+      .getVisibleCoordinates()
+      .map((tileid: any) => this.sourceCache.getTile(tileid));
   }
 }
 
@@ -320,12 +390,9 @@ export function setupLayer(
   program.aPos = gl.getAttribLocation(program, "aPos");
   program.uMatrix = gl.getUniformLocation(program, "uMatrix");
   program.uTexture = gl.getUniformLocation(program, "uTexture");
-  program.uOffsetX = gl.getUniformLocation(program, "uOffsetX");
-  program.uOffsetY = gl.getUniformLocation(program, "uOffsetY");
-  program.uDevicePixelRatio = gl.getUniformLocation(
-    program,
-    "uDevicePixelRatio"
-  );
+  program.uClipX = gl.getUniformLocation(program, "uClipX");
+  program.uClipY = gl.getUniformLocation(program, "uClipY");
+  program.uOpacity = gl.getUniformLocation(program, "uOpacity");
 
   const vertexArray = new Float32Array([0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1]);
 
@@ -335,9 +402,9 @@ export function setupLayer(
 
   // Initialize data
   gl.useProgram(program);
-  gl.uniform1f(program.uOffsetX, data.offsetX);
-  gl.uniform1f(program.uOffsetY, data.offsetY);
-  gl.uniform1f(program.uDevicePixelRatio, window.devicePixelRatio);
+  gl.uniform1f(program.uClipX, data.offsetX * gl.drawingBufferWidth);
+  gl.uniform1f(program.uClipY, data.offsetY * gl.drawingBufferHeight);
+  gl.uniform1f(program.uOpacity, data.opacity ?? 1);
 
   return program;
 }
@@ -346,13 +413,18 @@ export function setupLayer(
  * Renders visible tiles using the WebGL program.
  * Binds textures and draws triangles for each tile within the offset bounds.
  *
+ * Clip bounds are computed in device pixels (`gl.drawingBufferWidth/Height`)
+ * so the comparison edge matches `gl_FragCoord` exactly on any DPR. Blending
+ * uses premultiplied-alpha factors, matching how mapbox uploads raster tile
+ * textures, so transparent tile padding composites correctly.
+ *
  * @param gl - WebGL rendering context
  * @param _ - Transformation matrix (unused)
  * @param tiles - Array of visible tiles to render
  * @param program - Compiled WebGL program with cached locations
  * @param data - Current offset data controlling visibility bounds
- * @param width - Map container width in pixels
- * @param height - Map container height in pixels
+ * @param _width - Map container width in CSS pixels (unused)
+ * @param _height - Map container height in CSS pixels (unused)
  */
 export function render(
   gl: WebGLRenderingContext,
@@ -360,13 +432,22 @@ export function render(
   tiles: any[],
   program: ComparisonLayerProgram,
   data: ComparisonLayerData,
-  width: number,
-  height: number
+  _width: number,
+  _height: number
 ) {
   gl.useProgram(program);
-  gl.uniform1f(program.uOffsetX, data.offsetX * width);
-  gl.uniform1f(program.uOffsetY, data.offsetY * height);
-  gl.uniform1f(program.uDevicePixelRatio, window.devicePixelRatio);
+  gl.uniform1f(program.uClipX, data.offsetX * gl.drawingBufferWidth);
+  gl.uniform1f(program.uClipY, data.offsetY * gl.drawingBufferHeight);
+  gl.uniform1f(program.uOpacity, data.opacity ?? 1);
+
+  gl.enable(gl.BLEND);
+  gl.blendFuncSeparate(
+    gl.ONE,
+    gl.ONE_MINUS_SRC_ALPHA,
+    gl.ONE,
+    gl.ONE_MINUS_SRC_ALPHA
+  );
+
   tiles.forEach((tile) => {
     if (!tile.texture) return;
     gl.activeTexture(gl.TEXTURE0);
@@ -384,8 +465,6 @@ export function render(
     gl.uniformMatrix4fv(program.uMatrix, false, tile.tileID.projMatrix);
     gl.uniform1i(program.uTexture, 0);
     gl.depthFunc(gl.LESS);
-    //gl.enable(gl.BLEND);
-    //gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
   });
 }

--- a/lib/__tests__/CustomLayer.test.ts
+++ b/lib/__tests__/CustomLayer.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, vi } from "vitest";
+import { ComparisonLayer, render } from "../CustomLayer";
+import type { ComparisonLayerData } from "../CustomLayer";
+
+type FakeProgram = {
+  aPos: number;
+  uMatrix: object;
+  uTexture: object;
+  uClipX: object;
+  uClipY: object;
+  uOpacity: object;
+  vertexBuffer: object;
+};
+
+const makeProgram = (): FakeProgram => ({
+  aPos: 0,
+  uMatrix: { u: "uMatrix" },
+  uTexture: { u: "uTexture" },
+  uClipX: { u: "uClipX" },
+  uClipY: { u: "uClipY" },
+  uOpacity: { u: "uOpacity" },
+  vertexBuffer: { buffer: true }
+});
+
+const makeGl = () =>
+  (({
+    drawingBufferWidth: 2000,
+    drawingBufferHeight: 1000,
+    BLEND: "BLEND",
+    ONE: "ONE",
+    ONE_MINUS_SRC_ALPHA: "ONE_MINUS_SRC_ALPHA",
+    TEXTURE0: "TEXTURE0",
+    TEXTURE_2D: "TEXTURE_2D",
+    TEXTURE_WRAP_S: "TEXTURE_WRAP_S",
+    TEXTURE_WRAP_T: "TEXTURE_WRAP_T",
+    TEXTURE_MIN_FILTER: "TEXTURE_MIN_FILTER",
+    TEXTURE_MAG_FILTER: "TEXTURE_MAG_FILTER",
+    CLAMP_TO_EDGE: "CLAMP_TO_EDGE",
+    LINEAR: "LINEAR",
+    ARRAY_BUFFER: "ARRAY_BUFFER",
+    FLOAT: "FLOAT",
+    TRIANGLES: "TRIANGLES",
+    LESS: "LESS",
+    useProgram: vi.fn(),
+    uniform1f: vi.fn(),
+    uniform1i: vi.fn(),
+    uniformMatrix4fv: vi.fn(),
+    enable: vi.fn(),
+    blendFuncSeparate: vi.fn(),
+    activeTexture: vi.fn(),
+    bindTexture: vi.fn(),
+    texParameteri: vi.fn(),
+    bindBuffer: vi.fn(),
+    enableVertexAttribArray: vi.fn(),
+    vertexAttribPointer: vi.fn(),
+    depthFunc: vi.fn(),
+    drawArrays: vi.fn(),
+    deleteBuffer: vi.fn(),
+    deleteProgram: vi.fn()
+  } as unknown) as WebGLRenderingContext);
+
+const makeSourceCache = (tiles: any[] = []) => ({
+  getVisibleCoordinates: vi.fn(() => tiles.map((_, i) => i)),
+  getTile: vi.fn((i: number) => tiles[i]),
+  update: vi.fn()
+});
+
+const makeMap = ({
+  sourceCache = makeSourceCache(),
+  projectionName = "mercator"
+}: { sourceCache?: any; projectionName?: string } = {}) => {
+  const source = { on: vi.fn(), off: vi.fn() };
+  return {
+    on: vi.fn(),
+    off: vi.fn(),
+    addSource: vi.fn(),
+    removeSource: vi.fn(),
+    getSource: vi.fn(() => source),
+    triggerRepaint: vi.fn(),
+    getContainer: vi.fn(() => ({
+      getBoundingClientRect: () => ({ width: 1000, height: 500 })
+    })),
+    style: {
+      getOwnSourceCache: vi.fn(() => sourceCache),
+      _sourceCaches: {},
+      _layers: { layer01: {} }
+    },
+    transform: { projection: { name: projectionName } },
+    painter: { transform: {} },
+    _source: source
+  };
+};
+
+const addLayer = (
+  map: any,
+  data: ComparisonLayerData = { offsetX: 0.5, offsetY: 0 },
+  tileJson: any = null
+) => {
+  const program = makeProgram();
+  const onAddCallback = vi.fn(() => program) as any;
+  const renderCallback = vi.fn() as any;
+  const layer = new ComparisonLayer(
+    "layer01",
+    "source01",
+    tileJson,
+    data,
+    onAddCallback,
+    renderCallback
+  );
+  const gl = makeGl();
+  layer.onAdd(map, gl);
+  return { layer, gl, program, onAddCallback, renderCallback };
+};
+
+describe("ComparisonLayer (external-source mode)", () => {
+  it("does not add or own the source", () => {
+    const map = makeMap();
+    const { layer } = addLayer(map);
+
+    expect(map.addSource).not.toHaveBeenCalled();
+    expect(map.on).not.toHaveBeenCalled();
+    expect(map.style.getOwnSourceCache).toHaveBeenCalledWith("source01");
+
+    layer.onRemove();
+    expect(map.removeSource).not.toHaveBeenCalled();
+  });
+
+  it("falls back to _sourceCaches when getOwnSourceCache is unavailable", () => {
+    const sourceCache = makeSourceCache();
+    const map = makeMap();
+    map.style.getOwnSourceCache = undefined as any;
+    map.style._sourceCaches = { "other:source01": sourceCache };
+    const { layer, gl, renderCallback } = addLayer(map);
+
+    layer.render(gl, []);
+    expect(renderCallback).toHaveBeenCalled();
+  });
+
+  it("re-resolves the source cache lazily when it appears after onAdd", () => {
+    const sourceCache = makeSourceCache();
+    const map = makeMap();
+    map.style.getOwnSourceCache = vi
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValue(sourceCache);
+    const { layer, gl, renderCallback } = addLayer(map);
+
+    layer.render(gl, []);
+    expect(renderCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips rendering while the source cache is missing", () => {
+    const map = makeMap();
+    map.style.getOwnSourceCache = vi.fn(() => null);
+    map.style._sourceCaches = {};
+    const { layer, gl, renderCallback } = addLayer(map);
+
+    layer.render(gl, []);
+    expect(renderCallback).not.toHaveBeenCalled();
+  });
+});
+
+describe("ComparisonLayer (owned-source mode)", () => {
+  const tileJson = { type: "raster", tiles: ["https://example.com/{z}/{x}/{y}.png"] };
+
+  it("adds the source, marks it used, and removes it on onRemove", () => {
+    const map = makeMap();
+    const { layer } = addLayer(map, { offsetX: 0.5, offsetY: 0 }, tileJson);
+
+    expect(map.addSource).toHaveBeenCalledWith("source01", tileJson);
+    expect(map.style._layers.layer01).toEqual({ source: "source01" });
+    expect(map._source.on).toHaveBeenCalledWith("data", expect.any(Function));
+    expect(map.on).toHaveBeenCalledWith("move", expect.any(Function));
+
+    layer.onRemove();
+    expect(map.removeSource).toHaveBeenCalledWith("source01");
+    expect(map.off).toHaveBeenCalledWith("move", map.on.mock.calls[0][1]);
+    expect(map._source.off).toHaveBeenCalledWith(
+      "data",
+      map._source.on.mock.calls[0][1]
+    );
+  });
+});
+
+describe("ComparisonLayer.render guards", () => {
+  it("skips rendering when offsetX <= 0", () => {
+    const map = makeMap();
+    const { layer, gl, renderCallback } = addLayer(map, { offsetX: 0, offsetY: 0 });
+
+    layer.render(gl, []);
+    expect(renderCallback).not.toHaveBeenCalled();
+
+    layer.updateData({ offsetX: 0.4, offsetY: 0 });
+    expect(map.triggerRepaint).toHaveBeenCalled();
+    layer.render(gl, []);
+    expect(renderCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips rendering in true-globe projection", () => {
+    const map = makeMap({ projectionName: "globe" });
+    const { layer, gl, renderCallback } = addLayer(map);
+
+    layer.render(gl, []);
+    expect(renderCallback).not.toHaveBeenCalled();
+  });
+
+  it("passes visible tiles to the render callback", () => {
+    const tiles = [{ texture: { texture: {} }, tileID: { projMatrix: [1] } }];
+    const map = makeMap({ sourceCache: makeSourceCache(tiles) });
+    const { layer, gl, program, renderCallback } = addLayer(map);
+
+    layer.render(gl, []);
+    expect(renderCallback).toHaveBeenCalledWith(
+      gl,
+      [],
+      tiles,
+      program,
+      { offsetX: 0.5, offsetY: 0 },
+      1000,
+      500
+    );
+  });
+});
+
+describe("ComparisonLayer.onRemove", () => {
+  it("deletes the WebGL program and vertex buffer", () => {
+    const map = makeMap();
+    const { layer, gl, program } = addLayer(map);
+
+    layer.onRemove();
+    expect(gl.deleteBuffer).toHaveBeenCalledWith(program.vertexBuffer);
+    expect(gl.deleteProgram).toHaveBeenCalledWith(program);
+  });
+});
+
+describe("default render()", () => {
+  const data: ComparisonLayerData = { offsetX: 0.25, offsetY: 0 };
+
+  it("clips in device pixels and blends with premultiplied alpha", () => {
+    const gl = makeGl();
+    const program = makeProgram() as any;
+    const tile = { texture: { texture: { id: "tex" } }, tileID: { projMatrix: [42] } };
+
+    render(gl, [], [tile], program, data, 1000, 500);
+
+    expect(gl.uniform1f).toHaveBeenCalledWith(program.uClipX, 0.25 * 2000);
+    expect(gl.uniform1f).toHaveBeenCalledWith(program.uClipY, 0);
+    expect(gl.uniform1f).toHaveBeenCalledWith(program.uOpacity, 1);
+    expect(gl.enable).toHaveBeenCalledWith("BLEND");
+    expect(gl.blendFuncSeparate).toHaveBeenCalledWith(
+      "ONE",
+      "ONE_MINUS_SRC_ALPHA",
+      "ONE",
+      "ONE_MINUS_SRC_ALPHA"
+    );
+    expect(gl.uniformMatrix4fv).toHaveBeenCalledWith(program.uMatrix, false, [42]);
+    expect(gl.drawArrays).toHaveBeenCalledWith("TRIANGLES", 0, 6);
+  });
+
+  it("applies the opacity uniform", () => {
+    const gl = makeGl();
+    const program = makeProgram() as any;
+
+    render(gl, [], [], program, { ...data, opacity: 0.4 }, 1000, 500);
+    expect(gl.uniform1f).toHaveBeenCalledWith(program.uOpacity, 0.4);
+  });
+
+  it("skips tiles without a texture", () => {
+    const gl = makeGl();
+    const program = makeProgram() as any;
+
+    render(gl, [], [{ texture: null }], program, data, 1000, 500);
+    expect(gl.drawArrays).not.toHaveBeenCalled();
+  });
+});

--- a/lib/shaders/fragmentShader.ts
+++ b/lib/shaders/fragmentShader.ts
@@ -1,22 +1,28 @@
 export default `
     precision mediump float;
     varying vec2 vTexCoord;
-    varying float vOffsetX;
-    varying float vOffsetY;
     uniform sampler2D uTexture;
-    uniform float uDevicePixelRatio;
+    // Clip bounds in device pixels (same space as gl_FragCoord), so the
+    // comparison edge is exact on any devicePixelRatio.
+    uniform float uClipX;
+    uniform float uClipY;
+    uniform float uOpacity;
 
     void main() {
-        vec2 canvasCoord = gl_FragCoord.xy;
-        vec4 color = texture2D(uTexture, vTexCoord);
-
-        canvasCoord.x = canvasCoord.x / uDevicePixelRatio;
-        canvasCoord.y = canvasCoord.y / uDevicePixelRatio;
-
-        if (canvasCoord.x > vOffsetX || canvasCoord.y < vOffsetY) {
+        if (gl_FragCoord.x > uClipX || gl_FragCoord.y < uClipY) {
             discard;
         }
 
-        gl_FragColor = vec4(color.rgb, color.a);
+        vec4 color = texture2D(uTexture, vTexCoord);
+
+        // Fully transparent texels (e.g. the padding around bounded raster
+        // tiles) must not write color or depth.
+        if (color.a == 0.0) {
+            discard;
+        }
+
+        // Mapbox raster tile textures are premultiplied, so opacity scales
+        // all four channels.
+        gl_FragColor = color * uOpacity;
     }
 `;

--- a/lib/shaders/vertexShader.ts
+++ b/lib/shaders/vertexShader.ts
@@ -1,20 +1,12 @@
 export default `
     attribute vec2 aPos;
     uniform mat4 uMatrix;
-    uniform float uOffsetX;
-    uniform float uOffsetY;
     varying vec2 vTexCoord;
-
-    varying float vOffsetX;
-    varying float vOffsetY;
 
     float Extent = 8192.0;
 
     void main() {
-        vec4 a = uMatrix * vec4(aPos * Extent, 0, 1);
-        gl_Position = vec4(a.rgba);
+        gl_Position = uMatrix * vec4(aPos * Extent, 0, 1);
         vTexCoord = aPos;
-        vOffsetX = uOffsetX;
-        vOffsetY = uOffsetY;
     }
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "mapboxgl-comparison",
-  "version": "0.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mapboxgl-comparison",
-      "version": "0.0.5",
+      "version": "1.1.0",
       "devDependencies": {
         "@types/mapbox-gl": "^3.1.0",
         "@types/node": "^20.12.7",
         "typescript": "^5.2.2",
         "vite": "^5.4.21",
-        "vite-plugin-dts": "^3.9.0"
+        "vite-plugin-dts": "^3.9.0",
+        "vitest": "^2.1.9"
       },
       "peerDependencies": {
         "mapbox-gl": "^3.3.0"
@@ -422,10 +423,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@mapbox/geojson-rewind": {
       "version": "0.5.2",
@@ -898,6 +900,129 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/language-core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.11.1.tgz",
@@ -1029,6 +1154,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1045,11 +1180,48 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cheap-ruler": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-3.0.2.tgz",
       "integrity": "sha512-02T332h1/HTN6cDSufLP8x4JzDs2+VC+8qZ/N0kWIVPyc2xUkWwWh3B2fJxR7raXkL4Mq7k554mfuM9ofv/vGg==",
       "peer": true
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/commander": {
       "version": "9.5.0",
@@ -1086,12 +1258,13 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1100,6 +1273,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/earcut": {
@@ -1119,6 +1302,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1164,6 +1354,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1384,6 +1584,13 @@
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1397,12 +1604,13 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mapbox-gl": {
@@ -1463,10 +1671,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.3.1",
@@ -1510,6 +1719,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pbf": {
       "version": "3.2.1",
@@ -1690,6 +1916,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1714,6 +1947,20 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -1781,11 +2028,55 @@
         "node": ">=12"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "peer": true
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tweakpane": {
       "version": "4.0.3",
@@ -1902,6 +2193,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-dts": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.9.0.tgz",
@@ -1925,6 +2239,72 @@
       },
       "peerDependenciesMeta": {
         "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
           "optional": true
         }
       }
@@ -1965,6 +2345,23 @@
       },
       "peerDependencies": {
         "typescript": "*"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapboxgl-comparison",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "main": "dist/mapboxgl-comparison.js",
   "types": "dist/main.d.ts",
@@ -12,6 +12,7 @@
     "dev": "vite",
     "build": "tsc --p ./tsconfig-build.json && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
@@ -19,7 +20,8 @@
     "@types/node": "^20.12.7",
     "typescript": "^5.2.2",
     "vite": "^5.4.21",
-    "vite-plugin-dts": "^3.9.0"
+    "vite-plugin-dts": "^3.9.0",
+    "vitest": "^2.1.9"
   },
   "peerDependencies": {
     "mapbox-gl": "^3.3.0"

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["lib"]
+  "include": ["lib"],
+  "exclude": ["lib/__tests__"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import dts from "vite-plugin-dts";
 
 export default defineConfig({
-  plugins: [dts({ include: ["lib"] })],
+  plugins: [dts({ include: ["lib"], exclude: ["lib/__tests__"] })],
   build: {
     lib: {
       entry: resolve(__dirname, "lib/main.ts"),


### PR DESCRIPTION
## Summary

This PR fixes three rendering gaps found while adopting the library for the Cropwise Imagery compare slider (replacing a two-map `mapbox-gl-compare`-style setup with a single map), and adds an opt-in mode for apps whose framework owns source lifecycles. All changes are backwards-compatible; version bumped to **1.1.0**.

### Alpha blending + transparent-texel discard
Blending was commented out in `render()`, so raster tiles with transparent padding (e.g. imagery bounded to a farm/field polygon) rendered as opaque black rectangles over the basemap. Tiles are now composited with **premultiplied-alpha** blending (`ONE, ONE_MINUS_SRC_ALPHA`) — matching how mapbox uploads raster tile textures — and fully transparent texels are discarded so they don't write color or depth. A new optional `opacity` (0–1) on `ComparisonLayerData` scales the overlay.

### Device-pixel clipping (retina fix)
The clip edge was computed from the container's CSS width and divided by `devicePixelRatio` in the shader, which drifts on retina displays and fractional browser-zoom DPRs. The clip is now computed per frame in device pixels (`offsetX * gl.drawingBufferWidth`) and compared against `gl_FragCoord` directly — DPR cancels out exactly. Removes the `uDevicePixelRatio` uniform and simplifies the vertex shader.

### External-source mode
`tileJson` can now be `null`, in which case the layer never calls `addSource`/`removeSource` and only renders an existing raster source's tile cache. The host keeps the source loaded with a regular raster layer using `'raster-opacity': 0`, letting mapbox drive tile loading/updates through its normal pipeline. This drops the `_layers[id].source` hack and the manual `sourceCache.update()` on `move` for that mode, and plays well with react-map-gl, which restores sources across basemap style swaps. Usage is documented in the README.

### Robustness
- Skip rendering when `offsetX <= 0` / `offsetY >= 1` and skip tiles without a texture.
- Bail out of rendering in true globe projection (the mercator `tileID.projMatrix` would misproject the quads); above the globe→mercator transition zoom the overlay renders normally.
- Resolve the source cache via `style.getOwnSourceCache()` with a `_sourceCaches['other:'+id]` fallback, re-resolved lazily in `render()` (covers sources added after `onAdd`).
- Fix `on`/`off` listener leaks (`.bind()` in `off` never removed the original handler) by storing bound references.
- `onRemove` leaves externally-owned sources untouched.

### Tests & build
- New vitest suite (`lib/__tests__/CustomLayer.test.ts`, 12 tests) covering both source modes, render guards, offset updates, cleanup, and the default renderer's blending/clip uniforms. Run with `npm test`.
- Tests are excluded from the published build (`tsconfig-build.json`, `vite.config.ts`).

## Verification
- `npm test` — 12/12 pass
- `npm run build` — clean (tsc + vite, d.ts generated)
- Validated end-to-end in the Cropwise Imagery web app: bounded Sentinel/Planet RGB tiles composite correctly over the basemap (no black halos), the divider aligns with the DOM slider on retina and at browser zoom, and the overlay survives basemap style swaps in external-source mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)